### PR TITLE
fixed typo for firstname

### DIFF
--- a/components/Bio.js
+++ b/components/Bio.js
@@ -14,8 +14,8 @@ export default function Bio() {
         Hello, my full name is Mohamed Ayoub Zahir! too long right ? 😁
       </p>
       <p className="mb-4">
-        Well you can call me Ayoub, and on internet I just use medayz everywhere
-        as my username!
+        Well you can call me Mohamed, and on internet I just use medayz
+        everywhere as my username!
       </p>
       <p className="mb-8">
         I spend my time either creating bugs or fixing them 🐛


### PR DESCRIPTION
You forgot to follow the naming convention, See the image below.
https://en.wikipedia.org/wiki/Personal_name#/media/File:FML_names-2.png

Source: https://en.wikipedia.org/wiki/Personal_name